### PR TITLE
feat: show header with title and subtitle

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -162,18 +162,21 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 1rem 1.5rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
+    flex-shrink: 0;
 }
 
 header h1 {
     font-size: 1.75rem;
     font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: var(--primary-color);
     margin: 0;
 }
 


### PR DESCRIPTION
Make the header visible by changing CSS display from none to flex, with appropriate padding, border, and primary color styling.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)